### PR TITLE
Implement the feature from #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ A few tips for the org-mode feed configuration:
 
 * The tree should have a tag matching the string specified in the
   variable `rmh-elfeed-org-tree-id`.
-* Feeds must start with `http`.
+* Feeds must start with `http`, or be in
+  [org-mode link format](http://orgmode.org/org.html#Link-format) (the
+  URL should still start with `http`).
 * Tag rules must start with `entry-title: ` and end with a regular expression.
-* A tag rule tags all the posts that match the regular expression in the title 
+* A tag rule tags all the posts that match the regular expression in the title
   using a "tag hook" with `elfeed-make-tagger`. For more info see https://github.com/skeeto/elfeed
 * You may add text below the headline with the url to describe the
   feed or to add notes. They will be ignored.

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -164,7 +164,7 @@ all.  Which in my opinion makes the process more traceable."
 
   ;; Warn if needed
   (-each files 'rmh-elfeed-org-check-configuration-file)
-  
+
   ;; Clear elfeed structures
   (setq elfeed-feeds nil)
   (setq elfeed-new-entry-hook nil)
@@ -172,13 +172,16 @@ all.  Which in my opinion makes the process more traceable."
   ;; Convert org structure to elfeed structure
   (-each (rmh-elfeed-org-import-headlines-from-files files tree-id)
     (lambda (headline)
-      (let ((text (car headline)))
+      (let* ((text (car headline))
+             (hyperlink (s-match "^\\[\\[\\(http.+?\\)\\]\\(?:\\[.+?\\]\\)?\\]" text)))
+        (when hyperlink
+          (rmh-elfeed-org-export-feed (push (nth 1 hyperlink) (cdr headline))))
         (when (s-starts-with? "http" text)
           (rmh-elfeed-org-export-feed headline))
         (when (s-starts-with? "entry-title" text)
           (rmh-elfeed-org-export-entry-hook
            (rmh-elfeed-org-convert-headline-to-tagger-params headline))))))
-  
+
   ;; Tell user what we did
   (message "elfeed-org loaded %i feeds, %i rules"
            (length elfeed-feeds)


### PR DESCRIPTION
This pull request will allow headers to take the form of org mode hyperlinks in addition to naked URLs. This makes elfeed-org files much more readable and more suitable for distribution as well.

Essentially, we regex for the org-mode link and extract the URL, then swap out the full header text with just the URL. If its a naked URL, the regex returns nil and parsing proceeds as normal.

Note that this is my first time hacking on elisp, but it all works flawlessly for me.