### PR TITLE
feat(import-trees): Import headlines with STYLE=rmh-elfeed-org-tree-id

### DIFF
--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -73,7 +73,8 @@ current users."
       'headline
     (lambda (h)
       (when (or (member tree-id (org-element-property :tags h))
-                (equal tree-id (org-element-property :ID h))) h))))
+                (equal tree-id (org-element-property :ID h))
+                (equal tree-id (org-element-property :STYLE h))) h))))
 
 
 (defun rmh-elfeed-org-convert-tree-to-headlines (parsed-org)


### PR DESCRIPTION
I made this because I don't really like having non-informative tag, I prefer to hide this kind of stuff in the STYLE property.

With this change, elfeed-org also import trees with a STYLE property matching rmh-elfeed-org-tree-id.