### PR TITLE
org-mode links now modifies feed title.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ this is how elfeed users typically configure their subscriptions.
         ("http://www.anticscomic.com/?feed=rss2" comic)
         ("http://feeds.feedburner.com/blogspot/TPQSS" blog dev)))
 
+If you want to add a custom title to a feed, that is even more cumbersome...
+
 # Solution
 
 Org-mode makes the book keeping of tags and feeds much easier. Tags get
@@ -49,6 +51,10 @@ and every feed.
     **** http://ed-merks.blogspot.com/feeds/posts/default
     **** http://feeds.feedburner.com/eclipselive
     **** http://www.fosslc.org/drupal/rss.xml                             :video:
+
+If you choose to use org-mode links, the link description will be used as the
+feed's title in Elfeed. This is useful for feeds with long titles, and is
+cumbersome to setup using the standard Elfeed setup.
 
 ## The Configuration Tree
 

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -5,7 +5,7 @@
 ;; Author           : Remy Honig <remyhonig@gmail.com>
 ;; Package-Requires : ((elfeed "1.1.1") (org "8.2.7") (dash "2.10.0") (s "1.9.0"))
 ;; URL              : https://github.com/remyhonig/elfeed-org
-;; Version          : 20150412.1
+;; Version          : 20160814.1
 ;; Keywords         : news
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -153,11 +153,16 @@ all.  Which in my opinion makes the process more traceable."
              :entry-title (nth 0 tagger-params)
              :add (nth 1 tagger-params))))
 
-
 (defun rmh-elfeed-org-export-feed (headline)
   "Export HEADLINE to the proper `elfeed' structure."
-  (add-to-list 'elfeed-feeds headline))
-
+  (if (and (stringp (car (last headline)))
+           (> (length headline) 1))
+      (progn
+        (add-to-list 'elfeed-feeds (butlast headline))
+        (let ((feed (elfeed-db-get-feed (car headline))))
+          (setf (elfeed-meta feed :title) (car (last headline)))
+          (elfeed-meta feed :title)))
+    (add-to-list 'elfeed-feeds headline)))
 
 (defun rmh-elfeed-org-process (files tree-id)
   "Process headlines and taggers from FILES with org headlines with TREE-ID."
@@ -177,12 +182,12 @@ all.  Which in my opinion makes the process more traceable."
          (elfeed-tagger-hooks (-map 'rmh-elfeed-org-export-entry-hook elfeed-taggers)))
     (-each subscriptions 'rmh-elfeed-org-export-feed)
     (-each taggers 'rmh-elfeed-org-export-entry-hook))
-  
+
   ;; Tell user what we did
   (message "elfeed-org loaded %i feeds, %i rules"
            (length elfeed-feeds)
            (length elfeed-new-entry-hook)))
- 
+
 
 (defun rmh-elfeed-org-filter-taggers (headlines)
   "Filter tagging rules from the HEADLINES in the tree."
@@ -196,8 +201,12 @@ all.  Which in my opinion makes the process more traceable."
   (-non-nil (-map
              (lambda (headline)
                (let* ((text (car headline))
+                      (link-and-title (s-match "^\\[\\[\\(http.+?\\)\\]\\[\\(.+?\\)\\]\\]" text))
                       (hyperlink (s-match "^\\[\\[\\(http.+?\\)\\]\\(?:\\[.+?\\]\\)?\\]" text)))
                  (cond ((s-starts-with? "http" text) headline)
+                       (link-and-title (-concat (list (nth 1 hyperlink))
+                                                (cdr headline)
+                                                (list (nth 2 link-and-title))))
                        (hyperlink (-concat (list (nth 1 hyperlink)) (cdr headline))))))
              headlines)))
 

--- a/test/elfeed-org-test.el
+++ b/test/elfeed-org-test.el
@@ -53,7 +53,9 @@
   (xt-should (equal
               (rmh-elfeed-org-filter-subscriptions
                (rmh-elfeed-org-import-headlines-from-files '("test/fixture-feed-formats.org") "elfeed"))
-              '(("http://url" tag3 tag1) ("http://orgmodelink" tag3)))))
+              '(("http://url" tag3 tag1)
+                ("http://namedorgmodelink" tag3 "namedorgmodelink")
+                ("http://unnamedorgmodelink" tag3)))))
 
 (xt-deftest rmh-elfeed-org-import-headlines-from-files
   (xt-note "Use all feeds in a multiple trees tagged with the \"elfeed\" tag and inherited their parent's tags")

--- a/test/fixture-feed-formats.org
+++ b/test/fixture-feed-formats.org
@@ -5,4 +5,5 @@
 ** entry-title: \(linux\|gnome\)
 ** entry-title: \(apple\)
 ** http://url                                                                       :tag1:
-** [[http://orgmodelink][orgmodelink]]
+** [[http://namedorgmodelink][namedorgmodelink]]
+** [[http://unnamedorgmodelink]]


### PR DESCRIPTION
If an org-mode link is used, for instance
[[http://feeds.feedburner.com/GamasutraFeatureArticles][Gamasutra]] the
feed's title will be renamed to the description of the link (in this
example Gamasutra). #19 