### PR TITLE
Support ignore invalid feeds automatically

### DIFF
--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -53,6 +53,12 @@
   :group 'elfeed-org
   :type 'string)
 
+(defcustom rmh-elfeed-org-auto-ignore-invalid-feeds nil
+  "If non-nil, elfeed-org will mark the invalid feeds ignored
+  after fetch operation."
+  :group 'elfeed-org
+  :type 'bool)
+
 (defcustom rmh-elfeed-org-files (list "~/.emacs.d/elfeed.org")
   "The files where we look to find trees with the `rmh-elfeed-org-tree-id'."
   :group 'elfeed-org
@@ -64,6 +70,33 @@
   (when (not (file-exists-p file))
     (error "Elfeed-org cannot open %s.  Make sure it exists customize the variable \'rmh-elfeed-org-files\'"
            (abbreviate-file-name file))))
+
+(defun rmh-elfeed-org-mark-feed-ignore (url &optional notsave)
+  "Add tag `rmh-elfeed-org-ignore-tag' to target feed."
+  (dolist (org-file rmh-elfeed-org-files)
+    (with-current-buffer (find-file-noselect
+                          (expand-file-name org-file))
+      (org-mode)
+      (beginning-of-buffer)
+      (while (and (search-forward url nil t) (org-on-heading-p))
+        (let* ((org-special-ctrl-a/e t)
+               (org-special-ctrl-k t)
+               (cur-tags (org-get-tags))
+               (cur-tags-str (org-get-tags-string))
+               (new-tags-str cur-tags-str))
+          (unless (member rmh-elfeed-org-ignore-tag cur-tags)
+            (progn
+              (if (s-prefix? ":" new-tags-str)
+                  (setq new-tags-str (concat new-tags-str rmh-elfeed-org-ignore-tag ":"))
+                (setq new-tags-str (concat new-tags-str ":" rmh-elfeed-org-ignore-tag ":")))
+              (beginning-of-line)
+              (org-end-of-line)
+              (when cur-tags
+                (org-kill-line))
+              (insert "        " new-tags-str)))))
+      (unless notsave
+        (save-buffer))
+      (message "Ignore invalid feed: %s" url))))
 
 
 (defun rmh-elfeed-org-import-trees (tree-id)
@@ -225,7 +258,11 @@ all.  Which in my opinion makes the process more traceable."
   ;; Use an advice to load the configuration.
   (defadvice elfeed (before configure-elfeed activate)
     "Load all feed settings before elfeed is started."
-    (rmh-elfeed-org-process rmh-elfeed-org-files rmh-elfeed-org-tree-id)))
+    (rmh-elfeed-org-process rmh-elfeed-org-files rmh-elfeed-org-tree-id))
+  (add-hook 'elfeed-http-error-hooks (lambda (url status) (when rmh-elfeed-org-auto-ignore-invalid-feeds
+                                                            (rmh-elfeed-org-mark-feed-ignore url))))
+  (add-hook 'elfeed-parse-error-hooks (lambda (url error) (when rmh-elfeed-org-auto-ignore-invalid-feeds
+                                                            (rmh-elfeed-org-mark-feed-ignore url)))))
 
 
 (provide 'elfeed-org)

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -48,6 +48,10 @@
   :group 'elfeed-org
   :type 'string)
 
+(defcustom rmh-elfeed-org-ignore-tag "ignore"
+  "The tag on the feed trees that will be ignored."
+  :group 'elfeed-org
+  :type 'string)
 
 (defcustom rmh-elfeed-org-files (list "~/.emacs.d/elfeed.org")
   "The files where we look to find trees with the `rmh-elfeed-org-tree-id'."
@@ -117,7 +121,9 @@ all.  Which in my opinion makes the process more traceable."
   "Filter relevant entries from the LIST."
   (-filter
    (lambda (entry)
-     (string-match "\\(http\\|entry-title\\)" (car entry)))
+     (and
+      (string-match "\\(http\\|entry-title\\)" (car entry))
+      (not (member (intern rmh-elfeed-org-ignore-tag) entry))))
    list))
 
 

--- a/test/elfeed-org-test.el
+++ b/test/elfeed-org-test.el
@@ -81,6 +81,12 @@
               (rmh-elfeed-org-import-headlines-from-files '("test/fixture-one-tag.org" "test/fixture-one-id-no-feeds.org") "elfeed")
               '(("http1" tag1) ("http2")))))
 
+(xt-deftest rmh-elfeed-org-import-headlines-and-ignore-tags
+  (xt-note "Use all feeds in a multiple trees tagged with the \"elfeed\" tag and not match the \"ignore\" tag and inherited their parent's tags")
+  (xt-should (equal
+              (rmh-elfeed-org-import-headlines-from-files '("test/fixture-ignore-tag.org") "elfeed")
+              '(("http1" tag1) ("http3" tag3)))))
+
 (xt-deftest rmh-elfeed-org-gets-inherited-tags2
   (xt-note "Get all headlines with inherited tags")
   (xtd-return= (lambda (_) (progn (org-mode)

--- a/test/elfeed-org-test.el
+++ b/test/elfeed-org-test.el
@@ -87,6 +87,19 @@
               (rmh-elfeed-org-import-headlines-from-files '("test/fixture-ignore-tag.org") "elfeed")
               '(("http1" tag1) ("http3" tag3)))))
 
+(xt-deftest rmh-elfeed-org-mark-feed-ignore
+  (xt-note "Mark special feed with tag ignore.")
+  (xt-should (equal
+              (let* ((rmh-elfeed-org-files '("test/fixture-mark-feed-ignore.org")))
+                (rmh-elfeed-org-mark-feed-ignore "http://invalidurl" 'notsave)
+                (with-current-buffer (get-buffer "fixture-mark-feed-ignore.org")
+                  (buffer-string)))
+              "* tree1                                                              :elfeed:
+** http://invalidurl        :tag1:ignore:
+** [[http://namedorgmodelink][namedorgmodelink]]
+** [[http://invalidurl]]        :ignore:
+")))
+
 (xt-deftest rmh-elfeed-org-gets-inherited-tags2
   (xt-note "Get all headlines with inherited tags")
   (xtd-return= (lambda (_) (progn (org-mode)

--- a/test/fixture-ignore-tag.org
+++ b/test/fixture-ignore-tag.org
@@ -1,0 +1,6 @@
+* tree1                                                              :elfeed:
+** http1                                                               :tag1:
+** ignore subtree                                                    :ignore:
+*** http2                                                               :tag2:
+** http3                                                               :tag3:
+** http4                                                        :ignore:tag4:

--- a/test/fixture-mark-feed-ignore.org
+++ b/test/fixture-mark-feed-ignore.org
@@ -1,0 +1,4 @@
+* tree1                                                              :elfeed:
+** http://invalidurl                                                   :tag1:
+** [[http://namedorgmodelink][namedorgmodelink]]
+** [[http://invalidurl]]


### PR DESCRIPTION
Sometimes mark the invalid feeds with special tag and ignore them is necessary.