### PR TITLE
Feature/update ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,16 @@ env:
   # Therefore I don't support emacs-23
   # - EMACS=emacs23
 
-  # test the minimum supported requirements
   # 8.2.6 fails with (error "`recenter'ing a window that does not display current-buffer.")
-  - EVM_EMACS=emacs-24.4-bin ORG=release_8.2.7
+  - EVM_EMACS=emacs-25.1-travis ORG=release_8.2.7
 
   # test latest released emacs and org-mode
-  - EVM_EMACS=emacs-24.4-bin ORG=release_8.2.10
+  - EVM_EMACS=emacs-25.1-travis ORG=release_9.0.5
 
-  # test newest emacs with minimum supported org-mode
-  - EVM_EMACS=emacs-24.3-bin ORG=release_8.2.7
+  # test oldest supported emacs with minimum supported org-mode
+  - EVM_EMACS=emacs-24.3-travis ORG=release_8.2.7
 
-  # test newest emacs with latest released org-mode
-  - EVM_EMACS=emacs-24.3-bin ORG=release_8.2.10
+  # test oldest supported emacs with latest released org-mode
+  - EVM_EMACS=emacs-24.3-travis ORG=release_9.0.5
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: emacs-lisp
 sudo: required
 before_install:
-  - curl -fsSkL https://gist.github.com/rejeep/7736123/raw | sh
-  - export PATH="/home/travis/.cask/bin:$PATH"
-  - export PATH="/home/travis/.evm/bin:$PATH"
-  - evm install $EVM_EMACS --use || true
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
   - cask
   - git clone git://orgmode.org/org-mode.git && cd org-mode && git checkout ${ORG} && make autoloads && cd ..
 env:

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,13 @@ all: install build test clean
 
 # install dependencies
 install:
-	$(CASK) install
+	EMACS=${EMACS} $(CASK) install
 
 build:
-	$(CASK) build
+	EMACS=${EMACS} $(CASK) build
 
 test:
-	$(CASK) exec ert-runner ${LOAD-ORGMODE}
+	EMACS=${EMACS} $(CASK) exec ert-runner ${LOAD-ORGMODE}
+
 clean:
-	$(CASK) clean-elc
+	EMACS=${EMACS} $(CASK) clean-elc


### PR DESCRIPTION
Make changes needed to keep using EVM on the new Travis docker-based platform. See https://github.com/rejeep/evm/blob/master/README.md for more info.