### PR TITLE
Feature/ignore invalid feeds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: emacs-lisp
-sudo: required
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
   - cask

--- a/README.md
+++ b/README.md
@@ -49,11 +49,18 @@ and every feed.
     *** Eclipse                                                         :eclipse:
     **** http://blog.eclipse-tips.com/feeds/posts/default?alt=rss
     **** http://ed-merks.blogspot.com/feeds/posts/default
-    **** http://feeds.feedburner.com/eclipselive
+         A description of this feed can be written under any headline.
+         The text will be ignored by elfeed.
+    **** http://feeds.feedburner.com/eclipselive                         :ignore:
     **** http://www.fosslc.org/drupal/rss.xml                             :video:
 
-If you choose to use org-mode links, the link description will be used as the
-feed's title in Elfeed. This is useful for feeds with long titles.
+
+Some highlights:
+
+* `[[http://orgmode.org][Org Mode Links supported as well]]` If you choose to use org-mode links, the link description will be used as the feed's title in Elfeed. This is useful for feeds with long titles.
+* `entry-title: \(emacs\|org-mode\)` Tags any blog post with "emacs" or "org-mode" in the title according to it's given and inherited tags (in the example above "emacs", "mustread" and "dev").
+* `http://feeds.feedburner.com/eclipselive :ignore:` The "ignore" excludes the feed completely from your checked subscriptions. You can use another name for "ignore" by customizing `rmh-elfeed-org-ignore-tag`. These "ignore" tags are set by elfeed-org automatically on feed errors (wrong urls or renamed feeds for example) if `rmh-elfeed-org-auto-ignore-invalid-feeds` is set to `t`.
+
 
 ## The Configuration Tree
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and every feed.
     *** Eclipse                                                         :eclipse:
     **** http://blog.eclipse-tips.com/feeds/posts/default?alt=rss
     **** http://ed-merks.blogspot.com/feeds/posts/default
-         A description of this feed can be written under any headline.
+         A description of a feed can be written under any headline.
          The text will be ignored by elfeed.
     **** http://feeds.feedburner.com/eclipselive                         :ignore:
     **** http://www.fosslc.org/drupal/rss.xml                             :video:

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ versions, so you can assume `elfeed-org` will work for them.
 
 | org-mode | emacs |
 |----------|-------|
-| 8.2.7    | 24.4  |
-| 8.2.10   | 24.4  |
+| 8.2.7    | 25.1  |
+| 9.0.5    | 25.1  |
 | 8.2.7    | 24.3  |
-| 8.2.10   | 24.3  |
+| 9.0.5    | 24.3  |
 
 This package needs `org-mode 8.2.7` to run properly if you use the `emacs-24` distribution. The reason that that org-mode version is needed is because `org-mode 8.2.6` - at least in combination with `GNU Emacs 24.4.50.1` - causes the error `(error "recenter'ing a window that does not display current-buffer.")`.
 

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -48,6 +48,16 @@
   :group 'elfeed-org
   :type 'string)
 
+(defcustom rmh-elfeed-org-ignore-tag "ignore"
+  "The tag on the feed trees that will be ignored."
+  :group 'elfeed-org
+  :type 'string)
+
+(defcustom rmh-elfeed-org-auto-ignore-invalid-feeds nil
+  "If non-nil, elfeed-org will mark the invalid feeds ignored
+  after fetch operation."
+  :group 'elfeed-org
+  :type 'bool)
 
 (defcustom rmh-elfeed-org-files (list "~/.emacs.d/elfeed.org")
   "The files where we look to find trees with the `rmh-elfeed-org-tree-id'."
@@ -60,6 +70,33 @@
   (when (not (file-exists-p file))
     (error "Elfeed-org cannot open %s.  Make sure it exists customize the variable \'rmh-elfeed-org-files\'"
            (abbreviate-file-name file))))
+
+(defun rmh-elfeed-org-mark-feed-ignore (url &optional notsave)
+  "Add tag `rmh-elfeed-org-ignore-tag' to target feed."
+  (dolist (org-file rmh-elfeed-org-files)
+    (with-current-buffer (find-file-noselect
+                          (expand-file-name org-file))
+      (org-mode)
+      (beginning-of-buffer)
+      (while (and (search-forward url nil t) (org-on-heading-p))
+        (let* ((org-special-ctrl-a/e t)
+               (org-special-ctrl-k t)
+               (cur-tags (org-get-tags))
+               (cur-tags-str (org-get-tags-string))
+               (new-tags-str cur-tags-str))
+          (unless (member rmh-elfeed-org-ignore-tag cur-tags)
+            (progn
+              (if (s-prefix? ":" new-tags-str)
+                  (setq new-tags-str (concat new-tags-str rmh-elfeed-org-ignore-tag ":"))
+                (setq new-tags-str (concat new-tags-str ":" rmh-elfeed-org-ignore-tag ":")))
+              (beginning-of-line)
+              (org-end-of-line)
+              (when cur-tags
+                (org-kill-line))
+              (insert "        " new-tags-str)))))
+      (unless notsave
+        (save-buffer))
+      (message "Ignore invalid feed: %s" url))))
 
 
 (defun rmh-elfeed-org-import-trees (tree-id)
@@ -117,7 +154,9 @@ all.  Which in my opinion makes the process more traceable."
   "Filter relevant entries from the LIST."
   (-filter
    (lambda (entry)
-     (string-match "\\(http\\|entry-title\\)" (car entry)))
+     (and
+      (string-match "\\(http\\|entry-title\\)" (car entry))
+      (not (member (intern rmh-elfeed-org-ignore-tag) entry))))
    list))
 
 
@@ -219,7 +258,11 @@ all.  Which in my opinion makes the process more traceable."
   ;; Use an advice to load the configuration.
   (defadvice elfeed (before configure-elfeed activate)
     "Load all feed settings before elfeed is started."
-    (rmh-elfeed-org-process rmh-elfeed-org-files rmh-elfeed-org-tree-id)))
+    (rmh-elfeed-org-process rmh-elfeed-org-files rmh-elfeed-org-tree-id))
+  (add-hook 'elfeed-http-error-hooks (lambda (url status) (when rmh-elfeed-org-auto-ignore-invalid-feeds
+                                                            (rmh-elfeed-org-mark-feed-ignore url))))
+  (add-hook 'elfeed-parse-error-hooks (lambda (url error) (when rmh-elfeed-org-auto-ignore-invalid-feeds
+                                                            (rmh-elfeed-org-mark-feed-ignore url)))))
 
 
 (provide 'elfeed-org)

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -5,7 +5,7 @@
 ;; Author           : Remy Honig <remyhonig@gmail.com>
 ;; Package-Requires : ((elfeed "1.1.1") (org "8.2.7") (dash "2.10.0") (s "1.9.0"))
 ;; URL              : https://github.com/remyhonig/elfeed-org
-;; Version          : 20160814.1
+;; Version          : 20170422.1
 ;; Keywords         : news
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -93,7 +93,7 @@ the feed url."
               (org-on-heading-p)
               (rmh-elfeed-org-is-headline-contained-in-elfeed-tree))
         (org-toggle-tag rmh-elfeed-org-ignore-tag 'on))
-      (message "Ignore invalid feed: %s" url))))
+      (elfeed-log 'info "elfeed-org tagged '%s' in file '%s' with '%s' to be ignored" url org-file rmh-elfeed-org-ignore-tag))))
 
 
 (defun rmh-elfeed-org-import-trees (tree-id)
@@ -220,7 +220,7 @@ all.  Which in my opinion makes the process more traceable."
     (-each taggers 'rmh-elfeed-org-export-entry-hook))
 
   ;; Tell user what we did
-  (message "elfeed-org loaded %i feeds, %i rules"
+  (elfeed-log 'info "elfeed-org loaded %i feeds, %i rules"
            (length elfeed-feeds)
            (length elfeed-new-entry-hook)))
 
@@ -251,7 +251,7 @@ all.  Which in my opinion makes the process more traceable."
 (defun elfeed-org ()
   "Hook up rmh-elfeed-org to read the `org-mode' configuration when elfeed is run."
   (interactive)
-  (message "elfeed-org is set up to handle elfeed configuration.")
+  (elfeed-log 'info "elfeed-org is set up to handle elfeed configuration")
   ;; Use an advice to load the configuration.
   (defadvice elfeed (before configure-elfeed activate)
     "Load all feed settings before elfeed is started."

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -71,19 +71,28 @@
     (error "Elfeed-org cannot open %s.  Make sure it exists customize the variable \'rmh-elfeed-org-files\'"
            (abbreviate-file-name file))))
 
+(defun rmh-elfeed-org-is-headline-contained-in-elfeed-tree ()
+  "Is any ancestor a headline with the elfeed tree id.
+Return t if it does or nil if it does not."
+  (let ((result nil))
+    (save-excursion
+      (while (and (not result) (org-up-heading-safe))
+        (setq result (member rmh-elfeed-org-tree-id (org-get-tags))))
+    result)))
+
 (defun rmh-elfeed-org-mark-feed-ignore (url)
   "Set tag `rmh-elfeed-org-ignore-tag' to headlines containing
-the feed url. Warning: this applies to all headlines. Not just
-the headlines within an elfeed tree. It would be nice to have
-this fixed one day. The worst case scenario is that the ignored
-tag is toggled on a headline that is not within an elfeed tree."
+the feed url."
   (dolist (org-file rmh-elfeed-org-files)
     (with-current-buffer (find-file-noselect
                           (expand-file-name org-file))
       (org-mode)
       (beginning-of-buffer)
-      (while (and (search-forward url nil t) (org-on-heading-p))
-              (org-toggle-tag rmh-elfeed-org-ignore-tag 'on))
+      (while (and
+              (search-forward url nil t)
+              (org-on-heading-p)
+              (rmh-elfeed-org-is-headline-contained-in-elfeed-tree))
+        (org-toggle-tag rmh-elfeed-org-ignore-tag 'on))
       (message "Ignore invalid feed: %s" url))))
 
 

--- a/test/elfeed-org-test.el
+++ b/test/elfeed-org-test.el
@@ -94,10 +94,10 @@
                 (rmh-elfeed-org-mark-feed-ignore "http://invalidurl")
                 (with-current-buffer (get-buffer "fixture-mark-feed-ignore.org")
                   (buffer-string)))
-              "* tree1                                                              :elfeed:
-** http://invalidurl                                            :tag1:ignore:
+              "* tree1 :elfeed:
+** http://invalidurl :tag1:ignore:
 ** [[http://namedorgmodelink][namedorgmodelink]]
-** [[http://invalidurl]]                                             :ignore:
+** [[http://invalidurl]] :ignore:
 ")))
 
 (xt-deftest rmh-elfeed-org-gets-inherited-tags2

--- a/test/elfeed-org-test.el
+++ b/test/elfeed-org-test.el
@@ -91,13 +91,13 @@
   (xt-note "Mark special feed with tag ignore.")
   (xt-should (equal
               (let* ((rmh-elfeed-org-files '("test/fixture-mark-feed-ignore.org")))
-                (rmh-elfeed-org-mark-feed-ignore "http://invalidurl" 'notsave)
+                (rmh-elfeed-org-mark-feed-ignore "http://invalidurl")
                 (with-current-buffer (get-buffer "fixture-mark-feed-ignore.org")
                   (buffer-string)))
               "* tree1                                                              :elfeed:
-** http://invalidurl        :tag1:ignore:
+** http://invalidurl                                            :tag1:ignore:
 ** [[http://namedorgmodelink][namedorgmodelink]]
-** [[http://invalidurl]]        :ignore:
+** [[http://invalidurl]]                                             :ignore:
 ")))
 
 (xt-deftest rmh-elfeed-org-gets-inherited-tags2

--- a/test/elfeed-org-test.el
+++ b/test/elfeed-org-test.el
@@ -81,6 +81,25 @@
               (rmh-elfeed-org-import-headlines-from-files '("test/fixture-one-tag.org" "test/fixture-one-id-no-feeds.org") "elfeed")
               '(("http1" tag1) ("http2")))))
 
+(xt-deftest rmh-elfeed-org-import-headlines-and-ignore-tags
+  (xt-note "Use all feeds in a multiple trees tagged with the \"elfeed\" tag and not match the \"ignore\" tag and inherited their parent's tags")
+  (xt-should (equal
+              (rmh-elfeed-org-import-headlines-from-files '("test/fixture-ignore-tag.org") "elfeed")
+              '(("http1" tag1) ("http3" tag3)))))
+
+(xt-deftest rmh-elfeed-org-mark-feed-ignore
+  (xt-note "Mark special feed with tag ignore.")
+  (xt-should (equal
+              (let* ((rmh-elfeed-org-files '("test/fixture-mark-feed-ignore.org")))
+                (rmh-elfeed-org-mark-feed-ignore "http://invalidurl" 'notsave)
+                (with-current-buffer (get-buffer "fixture-mark-feed-ignore.org")
+                  (buffer-string)))
+              "* tree1                                                              :elfeed:
+** http://invalidurl        :tag1:ignore:
+** [[http://namedorgmodelink][namedorgmodelink]]
+** [[http://invalidurl]]        :ignore:
+")))
+
 (xt-deftest rmh-elfeed-org-gets-inherited-tags2
   (xt-note "Get all headlines with inherited tags")
   (xtd-return= (lambda (_) (progn (org-mode)

--- a/test/elfeed-org-test.el
+++ b/test/elfeed-org-test.el
@@ -94,10 +94,13 @@
                 (rmh-elfeed-org-mark-feed-ignore "http://invalidurl")
                 (with-current-buffer (get-buffer "fixture-mark-feed-ignore.org")
                   (buffer-string)))
-              "* tree1 :elfeed:
+
+              "* elfeed tree :elfeed:
 ** http://invalidurl :tag1:ignore:
 ** [[http://namedorgmodelink][namedorgmodelink]]
 ** [[http://invalidurl]] :ignore:
+* other tree
+** http://invalidurl
 ")))
 
 (xt-deftest rmh-elfeed-org-gets-inherited-tags2
@@ -173,6 +176,6 @@
                   (delete-region (point-min) (point-max))
                   (insert (org-element-interpret-data
                            (rmh-elfeed-org-flag-headlines parsed-org)))))
-              ("* tree1  :elfeed:\n-!-"
-               "* tree1                                                       :_flag_:elfeed:\n-!-"
+              ("* tree1 :elfeed:\n-!-"
+               "* tree1 :_flag_:elfeed:\n-!-"
                )))

--- a/test/fixture-ignore-tag.org
+++ b/test/fixture-ignore-tag.org
@@ -1,0 +1,6 @@
+* tree1                                                              :elfeed:
+** http1                                                               :tag1:
+** ignore subtree                                                    :ignore:
+*** http2                                                               :tag2:
+** http3                                                               :tag3:
+** http4                                                        :ignore:tag4:

--- a/test/fixture-mark-feed-ignore.org
+++ b/test/fixture-mark-feed-ignore.org
@@ -1,4 +1,4 @@
-* tree1                                                              :elfeed:
-** http://invalidurl                                                   :tag1:
+* tree1 :elfeed:
+** http://invalidurl :tag1:
 ** [[http://namedorgmodelink][namedorgmodelink]]
 ** [[http://invalidurl]]

--- a/test/fixture-mark-feed-ignore.org
+++ b/test/fixture-mark-feed-ignore.org
@@ -1,4 +1,6 @@
-* tree1 :elfeed:
+* elfeed tree :elfeed:
 ** http://invalidurl :tag1:
 ** [[http://namedorgmodelink][namedorgmodelink]]
 ** [[http://invalidurl]]
+* other tree
+** http://invalidurl

--- a/test/fixture-mark-feed-ignore.org
+++ b/test/fixture-mark-feed-ignore.org
@@ -1,0 +1,4 @@
+* tree1                                                              :elfeed:
+** http://invalidurl                                                   :tag1:
+** [[http://namedorgmodelink][namedorgmodelink]]
+** [[http://invalidurl]]

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -5,6 +5,7 @@
 
 (require 'xtest)
 (load-file "elfeed-org.el")
+(setq org-tags-column 0)
 
 ;;; Code:
 


### PR DESCRIPTION
- [x] make sure that no headlines are changed if they are not in an `:elfeed:` tagged tree