### PR TITLE
Avoid interning Org tag string faces

### DIFF
--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -124,7 +124,8 @@ all.  Which in my opinion makes the process more traceable."
       (lambda (h)
         (let* ((current-level (org-element-property :level h))
                (delta-level (- current-level level))
-               (delta-tags (mapcar 'intern (org-element-property :tags h)))
+               (delta-tags (--map (intern (substring-no-properties it))
+                                  (org-element-property :tags h)))
                (heading (org-element-property :raw-value h)))
           ;; update the tags stack when we visit a parent or sibling
           (unless (> delta-level 0)


### PR DESCRIPTION
The `intern` function, when called on a string which has text-properties, interns those text properties, so calling `symbol-name` on the symbol returns a string with the same properties.  This results in the interned tag symbols having the `org-tag` face, which is awkward if those strings are later inserted into a buffer.

Thanks for your work on elfeed-org!