### PR TITLE
Replace "~/.emacs.d" with user-emacs-directory.

### DIFF
--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -60,7 +60,7 @@
   :group 'elfeed-org
   :type 'bool)
 
-(defcustom rmh-elfeed-org-files (list "~/.emacs.d/elfeed.org")
+(defcustom rmh-elfeed-org-files (list (locate-user-emacs-file "elfeed.org"))
   "The files where we look to find trees with the `rmh-elfeed-org-tree-id'."
   :group 'elfeed-org
   :type '(repeat (file :tag "org-mode file")))


### PR DESCRIPTION
Emacs has been XDG compliant since v27.1.  So the default value of
'user-emacs-directory' is now "$XDG_CONFIG_HOME/emacs" instead of "~/.emacs.d".
Using a hard-coded value is not recommended.