### PR TITLE
Fix byte compile warning

### DIFF
--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -34,6 +34,7 @@
 
 (require 'elfeed)
 (require 'org)
+(require 'org-element)
 (require 'dash)
 (require 's)
 (require 'cl-lib)


### PR DESCRIPTION
On byte compile, Emacs warns several org functions are unknown. This commit fixes this issue.