### PR TITLE
Remove text properties from title

### DIFF
--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -218,8 +218,9 @@ all.  Which in my opinion makes the process more traceable."
            (> (length headline) 1))
       (progn
         (add-to-list 'elfeed-feeds (butlast headline))
-        (let ((feed (elfeed-db-get-feed (car headline))))
-          (setf (elfeed-meta feed :title) (car (last headline)))
+        (let ((feed (elfeed-db-get-feed (car headline)))
+              (title (substring-no-properties (car (last headline)))))
+          (setf (elfeed-meta feed :title) title)
           (elfeed-meta feed :title)))
     (add-to-list 'elfeed-feeds headline)))
 


### PR DESCRIPTION
Text properties can result in serialisation errors in
`elfeed-readable-p` as some text properties cannot be serialised and
read back. As a result feed entries with a title result in an error.
Stripping the properties from the title prevents this.