### PR TITLE
add support for file:// and gopher:// links

### DIFF
--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -175,7 +175,7 @@ all.  Which in my opinion makes the process more traceable."
   (-filter
    (lambda (entry)
      (and
-      (string-match "\\(http\\|entry-title\\)" (car entry))
+      (string-match "\\(http\\|gopher\\|file\\|entry-title\\)" (car entry))
       (not (member (intern rmh-elfeed-org-ignore-tag) entry))))
    list))
 


### PR DESCRIPTION
Elfeed has the ability to retrieve urls from gopher and the local file
system too, however elfeed-org would just ignore those links.

If someone could write tests for this it would be great, I'm not at all experienced with the test framework this package uses.
