### PR TITLE
Enable lexical binding & remove dependency on `s` and `dash`

### DIFF
--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -152,13 +152,13 @@ all.  Which in my opinion makes the process more traceable."
           ;; save current level to compare with next heading that will be visited
           (setq level current-level)
           ;; save the tags that might apply to potential children of the current heading
-          (push (nconc (car tags) delta-tags) tags)
+          (push (append (car tags) delta-tags) tags)
           ;; return the heading and inherited tags
           (if (and link description)
-              (nconc (list link)
+              (append (list link)
                        (car tags)
                        (list description))
-            (nconc (list (if link link heading))
+            (append (list (if link link heading))
                      (car tags))))))))
 
 ;; TODO: mark wrongly formatted feeds (PoC for unretrievable feeds)

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -1,4 +1,4 @@
-;;; elfeed-org.el --- Configure elfeed with one or more org-mode files
+;;; elfeed-org.el --- Configure elfeed with one or more org-mode files -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2014  Remy Honig
 

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -256,7 +256,7 @@ all.  Which in my opinion makes the process more traceable."
 
 (defun elfeed-org-run-new-entry-hook (entry)
   "Run ENTRY through elfeed-org taggers."
-  (dolist (hook elfeed-new-entry-hook)
+  (dolist (hook elfeed-org-new-entry-hook)
     (funcall hook entry)))
 
 (defun rmh-elfeed-apply-autotags-now-advice ()

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -87,7 +87,8 @@ Return t if it does or nil if it does not."
   (dolist (org-file rmh-elfeed-org-files)
     (with-current-buffer (find-file-noselect
                           (expand-file-name org-file))
-      (org-mode)
+      (let ((org-inhibit-startup t))
+        (org-mode))
       (goto-char (point-min))
       (while (and
               (search-forward url nil t)
@@ -189,7 +190,8 @@ all.  Which in my opinion makes the process more traceable."
   (cl-remove-duplicates
    (mapcan (lambda (file)
              (with-current-buffer (find-file-noselect (expand-file-name file))
-               (org-mode)
+               (let ((org-inhibit-startup t))
+                 (org-mode))
                (rmh-elfeed-org-cleanup-headlines
                 (rmh-elfeed-org-filter-relevant
                  (rmh-elfeed-org-convert-tree-to-headlines
@@ -297,12 +299,13 @@ Argument LEVEL current level in the tree."
 Argument OPML-FILE filename of the OPML file."
   (interactive "FInput OPML file: ")
   (let* ((xml (xml-parse-file opml-file))
-        (content (rmh-elfeed-org-convert-opml-to-org xml 0)))
+         (content (rmh-elfeed-org-convert-opml-to-org xml 0)))
     (with-current-buffer (get-buffer-create "*Imported Org Feeds*")
       (erase-buffer)
       (insert (format "* Imported Feeds            :%s:\n" rmh-elfeed-org-tree-id))
       (insert content)
-      (org-mode)
+      (let ((org-inhibit-startup t))
+        (org-mode))
       (pop-to-buffer (current-buffer)))))
 
 
@@ -312,7 +315,8 @@ Argument ORG-BUFFER the buffer to write the OPML content to."
   (let (need-ends
         opml-body)
     (with-current-buffer org-buffer
-      (org-mode)
+      (let ((org-inhibit-startup t))
+        (org-mode))
       (org-element-map (rmh-elfeed-org-import-trees
                         rmh-elfeed-org-tree-id) 'headline
         (lambda (h)

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -60,7 +60,8 @@
   :type 'bool)
 
 (defcustom rmh-elfeed-org-files (list (locate-user-emacs-file "elfeed.org"))
-  "The files where we look to find trees with the `rmh-elfeed-org-tree-id'."
+  "The files where we look to find trees with the `rmh-elfeed-org-tree-id'.
+In this file paths can be given relative to `org-directory'."
   :group 'elfeed-org
   :type '(repeat (file :tag "org-mode file")))
 
@@ -69,7 +70,7 @@
 
 (defun rmh-elfeed-org-check-configuration-file (file)
   "Make sure FILE exists."
-  (when (not (file-exists-p file))
+  (when (not (file-exists-p (expand-file-name file org-directory)))
     (error "Elfeed-org cannot open %s.  Make sure it exists or customize the variable \'rmh-elfeed-org-files\'"
            (abbreviate-file-name file))))
 
@@ -190,7 +191,8 @@ all.  Which in my opinion makes the process more traceable."
   (cl-remove-duplicates
    (mapcan (lambda (file)
              (let ((org-inhibit-startup t))
-               (with-current-buffer (find-file-noselect (expand-file-name file))
+               (with-current-buffer (find-file-noselect
+                                     (expand-file-name file org-directory))
                  (org-mode)
                  (rmh-elfeed-org-cleanup-headlines
                   (rmh-elfeed-org-filter-relevant
@@ -369,7 +371,8 @@ because most of Feed/RSS readers only support trees of 2 levels deep."
   (interactive)
   (let ((opml-body (cl-loop for org-file in rmh-elfeed-org-files
                              concat (rmh-elfeed-org-convert-org-to-opml
-                                     (find-file-noselect (expand-file-name org-file))))))
+                                     (find-file-noselect (expand-file-name org-file
+                                                                           org-directory))))))
     (with-current-buffer (get-buffer-create "*Exported OPML Feeds*")
       (erase-buffer)
       (insert "<?xml version=\"1.0\"?>\n")

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -259,7 +259,8 @@ all.  Which in my opinion makes the process more traceable."
 (defun rmh-elfeed-apply-autotags-now-advice ()
   "Make entry title matching rules works with `elfeed-apply-autotags-now'."
   (interactive)
-  (let* ((headlines (rmh-elfeed-org-import-headlines-from-files rmh-elfeed-org-files tree-id))
+  (let* ((headlines (rmh-elfeed-org-import-headlines-from-files
+                     rmh-elfeed-org-files rmh-elfeed-org-tree-id))
          (taggers (rmh-elfeed-org-filter-taggers headlines))
          (elfeed-taggers (mapcar #'rmh-elfeed-org-convert-headline-to-tagger-params taggers))
          (entry-match-taggers (mapcar (lambda (tagger-params)

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -259,9 +259,7 @@ all.  Which in my opinion makes the process more traceable."
 (defun rmh-elfeed-apply-autotags-now-advice ()
   "Make entry title matching rules works with `elfeed-apply-autotags-now'."
   (interactive)
-  (let* ((headlines (rmh-elfeed-org-import-headlines-from-files
-                     rmh-elfeed-org-files rmh-elfeed-org-tree-id))
-         (subscriptions (rmh-elfeed-org-filter-subscriptions headlines))
+  (let* ((headlines (rmh-elfeed-org-import-headlines-from-files rmh-elfeed-org-files tree-id))
          (taggers (rmh-elfeed-org-filter-taggers headlines))
          (elfeed-taggers (mapcar #'rmh-elfeed-org-convert-headline-to-tagger-params taggers))
          (entry-match-taggers (mapcar (lambda (tagger-params)

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -387,16 +387,16 @@ because most of Feed/RSS readers only support trees of 2 levels deep."
       (xml-mode)
       (pop-to-buffer (current-buffer)))))
 
+(defun rmh-elfeed-org-process-advice ()
+  "Advice to add to `elfeed' to load the configuration before it is run."
+  (rmh-elfeed-org-process rmh-elfeed-org-files rmh-elfeed-org-tree-id))
 
 ;;;###autoload
 (defun elfeed-org ()
   "Hook up rmh-elfeed-org to read the `org-mode' configuration when elfeed is run."
   (interactive)
   (elfeed-log 'info "elfeed-org is set up to handle elfeed configuration")
-  ;; Use an advice to load the configuration.
-  (defadvice elfeed (before configure-elfeed activate)
-    "Load all feed settings before elfeed is started."
-    (rmh-elfeed-org-process rmh-elfeed-org-files rmh-elfeed-org-tree-id))
+  (advice-add #'elfeed :before #'rmh-elfeed-org-process-advice)
   (add-hook 'elfeed-new-entry-hook #'elfeed-org-run-new-entry-hook)
   (advice-add 'elfeed-apply-autotags-now :after #'rmh-elfeed-apply-autotags-now-advice)
   (add-hook 'elfeed-http-error-hooks (lambda (url status)

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -397,12 +397,14 @@ because most of Feed/RSS readers only support trees of 2 levels deep."
   (advice-add #'elfeed :before #'rmh-elfeed-org-process-advice)
   (add-hook 'elfeed-new-entry-hook #'elfeed-org-run-new-entry-hook)
   (advice-add 'elfeed-apply-autotags-now :after #'rmh-elfeed-apply-autotags-now-advice)
-  (add-hook 'elfeed-http-error-hooks (lambda (url status)
-                                       (when rmh-elfeed-org-auto-ignore-invalid-feeds
-                                         (rmh-elfeed-org-mark-feed-ignore url))))
-  (add-hook 'elfeed-parse-error-hooks (lambda (url error)
-                                        (when rmh-elfeed-org-auto-ignore-invalid-feeds
-                                          (rmh-elfeed-org-mark-feed-ignore url)))))
+  (add-hook 'elfeed-http-error-hooks
+            (lambda (url _status)
+              (when rmh-elfeed-org-auto-ignore-invalid-feeds
+                (rmh-elfeed-org-mark-feed-ignore url))))
+  (add-hook 'elfeed-parse-error-hooks
+            (lambda (url _error)
+              (when rmh-elfeed-org-auto-ignore-invalid-feeds
+                (rmh-elfeed-org-mark-feed-ignore url)))))
 
 
 (provide 'elfeed-org)

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -240,9 +240,7 @@ all.  Which in my opinion makes the process more traceable."
 
   ;; Convert org structure to elfeed structure and register taggers and subscriptions
   (let* ((headlines (rmh-elfeed-org-import-headlines-from-files files tree-id))
-         (taggers (rmh-elfeed-org-filter-taggers headlines))
-         (elfeed-taggers (mapcar #'rmh-elfeed-org-convert-headline-to-tagger-params taggers))
-         (elfeed-tagger-hooks (mapcar #'rmh-elfeed-org-export-entry-hook elfeed-taggers)))
+         (taggers (rmh-elfeed-org-filter-taggers headlines)))
     (mapc #'rmh-elfeed-org-export-feed headlines)
     (mapc #'rmh-elfeed-org-export-entry-hook taggers))
 

--- a/elfeed-org.el
+++ b/elfeed-org.el
@@ -84,21 +84,21 @@ Return t if it does or nil if it does not."
 
 (defun rmh-elfeed-org-mark-feed-ignore (url)
   "Set tag `rmh-elfeed-org-ignore-tag' to headlines containing the feed URL."
-  (dolist (org-file rmh-elfeed-org-files)
-    (with-current-buffer (find-file-noselect
-                          (expand-file-name org-file))
-      (let ((org-inhibit-startup t))
-        (org-mode))
-      (goto-char (point-min))
-      (while (and
-              (search-forward url nil t)
-              ;; Prefer outline-on-heading-p because org-on-heading-p
-              ;; is obsolete but org-at-heading-p was only introduced
-              ;; in org 9.0:
-              (outline-on-heading-p t)
-              (rmh-elfeed-org-is-headline-contained-in-elfeed-tree))
-        (org-toggle-tag rmh-elfeed-org-ignore-tag 'on))
-      (elfeed-log 'info "elfeed-org tagged '%s' in file '%s' with '%s' to be ignored" url org-file rmh-elfeed-org-ignore-tag))))
+  (let ((org-inhibit-startup t))
+    (dolist (org-file rmh-elfeed-org-files)
+      (with-current-buffer (find-file-noselect
+                            (expand-file-name org-file))
+        (org-mode)
+        (goto-char (point-min))
+        (while (and
+                (search-forward url nil t)
+                ;; Prefer outline-on-heading-p because org-on-heading-p
+                ;; is obsolete but org-at-heading-p was only introduced
+                ;; in org 9.0:
+                (outline-on-heading-p t)
+                (rmh-elfeed-org-is-headline-contained-in-elfeed-tree))
+          (org-toggle-tag rmh-elfeed-org-ignore-tag 'on))
+        (elfeed-log 'info "elfeed-org tagged '%s' in file '%s' with '%s' to be ignored" url org-file rmh-elfeed-org-ignore-tag)))))
 
 
 (defun rmh-elfeed-org-import-trees (tree-id)
@@ -189,14 +189,14 @@ all.  Which in my opinion makes the process more traceable."
   "Visit all FILES and return the headlines stored under tree tagged TREE-ID or with the \":ID:\" TREE-ID in one list."
   (cl-remove-duplicates
    (mapcan (lambda (file)
-             (with-current-buffer (find-file-noselect (expand-file-name file))
-               (let ((org-inhibit-startup t))
-                 (org-mode))
-               (rmh-elfeed-org-cleanup-headlines
-                (rmh-elfeed-org-filter-relevant
-                 (rmh-elfeed-org-convert-tree-to-headlines
-                  (rmh-elfeed-org-import-trees tree-id)))
-                (intern tree-id))))
+             (let ((org-inhibit-startup t))
+               (with-current-buffer (find-file-noselect (expand-file-name file))
+                 (org-mode)
+                 (rmh-elfeed-org-cleanup-headlines
+                  (rmh-elfeed-org-filter-relevant
+                   (rmh-elfeed-org-convert-tree-to-headlines
+                    (rmh-elfeed-org-import-trees tree-id)))
+                  (intern tree-id)))))
            files)
    :test #'equal))
 


### PR DESCRIPTION
Hi. I was investigating why a bug was happening in Doom Emacs and decided to bring this package up to modern standards. I have enabled lexical binding and replaced the functions from `s` and `dash` with newer built-in ones. This means this package now depends on Emacs28. 