### PR TITLE
Use named code blocks in `README.md` (for syntax highlighting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,21 @@ Maintaining tags for all my rss feeds is cumbersome using the regular flat list
 where there is no hierarchy and tag names are duplicated a lot. For example
 this is how elfeed users typically configure their subscriptions.
 
-    (defvar elfeed-feeds-alist
-      '(("http://threesixty360.wordpress.com/feed/" blog math)
-        ("http://www.50ply.com/atom.xml" blog dev)
-        ("http://blog.cryptographyengineering.com/feeds/posts/default" blog)
-        ("http://abstrusegoose.com/feed.xml" comic)
-        ("http://accidental-art.tumblr.com/rss" image math)
-        ("http://english.bouletcorp.com/feed/" comic)
-        ("http://curiousprogrammer.wordpress.com/feed/" blog dev)
-        ("http://feeds.feedburner.com/amazingsuperpowers" comic)
-        ("http://amitp.blogspot.com/feeds/posts/default" blog dev)
-        ("http://pages.cs.wisc.edu/~psilord/blog/rssfeed.rss" blog)
-        ("http://www.anticscomic.com/?feed=rss2" comic)
-        ("http://feeds.feedburner.com/blogspot/TPQSS" blog dev)))
+```emacs-lisp
+(defvar elfeed-feeds-alist
+  '(("http://threesixty360.wordpress.com/feed/" blog math)
+    ("http://www.50ply.com/atom.xml" blog dev)
+    ("http://blog.cryptographyengineering.com/feeds/posts/default" blog)
+    ("http://abstrusegoose.com/feed.xml" comic)
+    ("http://accidental-art.tumblr.com/rss" image math)
+    ("http://english.bouletcorp.com/feed/" comic)
+    ("http://curiousprogrammer.wordpress.com/feed/" blog dev)
+    ("http://feeds.feedburner.com/amazingsuperpowers" comic)
+    ("http://amitp.blogspot.com/feeds/posts/default" blog dev)
+    ("http://pages.cs.wisc.edu/~psilord/blog/rssfeed.rss" blog)
+    ("http://www.anticscomic.com/?feed=rss2" comic)
+    ("http://feeds.feedburner.com/blogspot/TPQSS" blog dev)))
+```
 
 If you want to add a custom title to a feed, that is even more cumbersome...
 
@@ -31,31 +33,32 @@ Org-mode makes the book keeping of tags and feeds much easier. Tags get
 inherited from parent headlines so there is no need to specify tags for each
 and every feed.
 
-    * Blogs                                                              :elfeed:
-    ** entry-title: \(linux\|linus\|ubuntu\|kde\|gnome\)                  :linux:
-    ** http://git-annex.branchable.com/design/assistant/blog/index.rss :mustread:
-    ** http://feeds.feedburner.com/InformationIsBeautiful
-    ** [[http://orgmode.org][Org Mode Links supported as well]]
-    ** Software Development                                                 :dev:
-    *** Emacs                                                    :emacs:mustread:
-    **** http://www.terminally-incoherent.com/blog/feed
-    **** http://nullprogram.com/feed
-    **** entry-title: \(emacs\|org-mode\)
-    **** http://planet.emacsen.org/atom.xml
-    **** [[toobnix:154][EmacsConf]]
-    *** Web Development                                                     :web:
-    **** http://planet.phpunit.de/atom.xml
-    **** http://feeds.feedburner.com/symfony/blog
-    **** http://feeds.feedburner.com/qooxdoo/blog/content
-    *** Eclipse                                                         :eclipse:
-    **** http://blog.eclipse-tips.com/feeds/posts/default?alt=rss
-    **** http://ed-merks.blogspot.com/feeds/posts/default
-         A description of a feed can be written under any headline.
-         The text will be ignored by elfeed.
-    **** http://feeds.feedburner.com/eclipselive                         :ignore:
-    **** http://www.fosslc.org/drupal/rss.xml                             :video:
-    #+link toobnix https://toobnix.org/feeds/videos.xml?videoChannelId=
-
+```org
+* Blogs                                                              :elfeed:
+** entry-title: \(linux\|linus\|ubuntu\|kde\|gnome\)                  :linux:
+** http://git-annex.branchable.com/design/assistant/blog/index.rss :mustread:
+** http://feeds.feedburner.com/InformationIsBeautiful
+** [[http://orgmode.org][Org Mode Links supported as well]]
+** Software Development                                                 :dev:
+*** Emacs                                                    :emacs:mustread:
+**** http://www.terminally-incoherent.com/blog/feed
+**** http://nullprogram.com/feed
+**** entry-title: \(emacs\|org-mode\)
+**** http://planet.emacsen.org/atom.xml
+**** [[toobnix:154][EmacsConf]]
+*** Web Development                                                     :web:
+**** http://planet.phpunit.de/atom.xml
+**** http://feeds.feedburner.com/symfony/blog
+**** http://feeds.feedburner.com/qooxdoo/blog/content
+*** Eclipse                                                         :eclipse:
+**** http://blog.eclipse-tips.com/feeds/posts/default?alt=rss
+**** http://ed-merks.blogspot.com/feeds/posts/default
+     A description of a feed can be written under any headline.
+     The text will be ignored by elfeed.
+**** http://feeds.feedburner.com/eclipselive                         :ignore:
+**** http://www.fosslc.org/drupal/rss.xml                             :video:
+#+link toobnix https://toobnix.org/feeds/videos.xml?videoChannelId=
+```
 
 Some highlights:
 
@@ -89,14 +92,18 @@ now with the value of `rmh-elfeed-org-tree-id`.
 
 So instead of
 
-    * Blogs
-     :PROPERTIES:
-     :ID: elfeed
-     :END:
+```org
+* Blogs
+ :PROPERTIES:
+ :ID: elfeed
+ :END:
+```
 
 I recommend to use
 
-    * Blogs                                                              :elfeed:
+```org
+* Blogs                                                              :elfeed:
+```
 
 # Tips
 A few tips for the org-mode feed configuration:
@@ -131,38 +138,46 @@ This package is part of the excellent [Spacemacs](http://spacemacs.org/). See [E
 ## Through MELPA
 [![MELPA](http://melpa.org/packages/elfeed-org-badge.svg)](http://melpa.org/#/elfeed-org)
 
-    ;; Install through package manager
-    M-x package-install <ENTER>
-    elfeed-org <ENTER>
+```
+;; Install through package manager
+M-x package-install <ENTER>
+elfeed-org <ENTER>
+```
 
 ## Manual
 
 Download elfeed-org
 
-    cd ~/.emacs.d/lisp
-    wget https://github.com/remyhonig/elfeed-org/blob/master/elfeed-org.el
+```ShellSession
+$ cd ~/.emacs.d/lisp
+$ wget https://github.com/remyhonig/elfeed-org/blob/master/elfeed-org.el
+```
 
 Install the package in Emacs
 
-    C-x C-f ~/.emacs.d/lisp/elfeed-org.el <ENTER>
-    M-x package-install-from-buffer <ENTER>
+```
+C-x C-f ~/.emacs.d/lisp/elfeed-org.el <ENTER>
+M-x package-install-from-buffer <ENTER>
+```
 
 # Initialization
 
 In your initialization script add the following:
 
-    ;; Load elfeed-org
-    (require 'elfeed-org)
+```emacs-lisp
+;; Load elfeed-org
+(require 'elfeed-org)
 
-    ;; Initialize elfeed-org
-    ;; This hooks up elfeed-org to read the configuration when elfeed
-    ;; is started with =M-x elfeed=
-    (elfeed-org)
+;; Initialize elfeed-org
+;; This hooks up elfeed-org to read the configuration when elfeed
+;; is started with =M-x elfeed=
+(elfeed-org)
 
-    ;; Optionally specify a number of files containing elfeed
-    ;; configuration. If not set then the location below is used.
-    ;; Note: The customize interface is also supported.
-    (setq rmh-elfeed-org-files (list "~/.emacs.d/elfeed.org"))
+;; Optionally specify a number of files containing elfeed
+;; configuration. If not set then the location below is used.
+;; Note: The customize interface is also supported.
+(setq rmh-elfeed-org-files (list "~/.emacs.d/elfeed.org"))
+```
     
 # Feature requests and bug fixes
 


### PR DESCRIPTION
Making it a bit prettier/easier to read for when it's rendered on github (via gfm) 😃

Changed all code blocks (for uniformity) even though some syntax is not recognized or needed.