### PR TITLE
Fix org-mode link format link

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ A few tips for the org-mode feed configuration:
 * The tree should have a tag matching the string specified in the
   variable `rmh-elfeed-org-tree-id`.
 * Feeds must start with `http`, or be in
-  [org-mode link format](http://orgmode.org/org.html#Link-format) (the
+  [org-mode link format](http://orgmode.org/org.html#Link-Format) (the
   URL should still start with `http`).
 * Tag rules must start with `entry-title: ` and end with a regular expression.
 * A tag rule tags all the posts that match the regular expression in the title


### PR DESCRIPTION
the org-mode link format link previously had incorrect capitalization so it only linked to the top of the org manual.